### PR TITLE
Enhance CLI URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # TradrXBridge
+
+A minimal demo trading application with simple persistent storage.
+
+## Requirements
+
+- Python 3
+- Flask
+- Requests
+
+Install dependencies:
+
+```bash
+pip install Flask requests
+```
+
+By default, data is saved to `tradrx_data.json` in the current
+directory. You can set the `TRADRX_DATA_FILE` environment variable to
+change the storage path.
+
+## Running the server
+
+```bash
+flask run -p 5001 --app tradrxbridge.app
+```
+
+Trades and positions will persist between restarts using the JSON file
+described above.
+
+Each trade receives an auto-incrementing ID and timestamp. You can
+retrieve or cancel a trade by ID using the CLI.
+
+## Using the CLI
+
+In a separate terminal, you can place trades or view positions:
+
+The CLI uses the `API_URL` environment variable to locate the server.
+You can also override it with the `--api` flag.
+
+```bash
+python tradrxbridge/cli.py --api http://localhost:5001 trade BTC buy 1 30000
+python tradrxbridge/cli.py --api http://localhost:5001 positions
+python tradrxbridge/cli.py --api http://localhost:5001 trades
+python tradrxbridge/cli.py --api http://localhost:5001 trade-info 1
+python tradrxbridge/cli.py --api http://localhost:5001 cancel 1
+```

--- a/tradrxbridge/__init__.py
+++ b/tradrxbridge/__init__.py
@@ -1,0 +1,5 @@
+"""TradrXBridge package."""
+
+from .app import app  # noqa: F401
+
+__all__ = ['app']

--- a/tradrxbridge/app.py
+++ b/tradrxbridge/app.py
@@ -1,0 +1,94 @@
+from flask import Flask, request, jsonify
+from datetime import datetime
+from . import storage
+
+app = Flask(__name__)
+
+# Persistent storage for trades and positions
+data = storage.load_data()
+positions = data.get('positions', {})
+trades = data.get('trades', [])
+next_id = data.get('next_id', len(trades) + 1)
+
+
+@app.route('/trade', methods=['POST'])
+def trade():
+    global next_id
+    data = request.get_json()
+    symbol = data.get('symbol')
+    action = data.get('action')  # 'buy' or 'sell'
+    qty = data.get('quantity', 0)
+    price = data.get('price', 0)
+
+    if not symbol or action not in {'buy', 'sell'}:
+        return jsonify({'error': 'Invalid trade data'}), 400
+
+    trade = {
+        'id': next_id,
+        'symbol': symbol,
+        'action': action,
+        'quantity': qty,
+        'price': price,
+        'timestamp': datetime.utcnow().isoformat() + 'Z'
+    }
+    next_id += 1
+    trades.append(trade)
+
+    if action == 'buy':
+        positions[symbol] = positions.get(symbol, 0) + qty
+    else:
+        positions[symbol] = positions.get(symbol, 0) - qty
+
+    storage.save_data({
+        'positions': positions,
+        'trades': trades,
+        'next_id': next_id,
+    })
+
+    return jsonify({'status': 'success', 'trade': trade})
+
+
+@app.route('/positions', methods=['GET'])
+def get_positions():
+    return jsonify(positions)
+
+
+@app.route('/trades', methods=['GET'])
+def get_trades():
+    return jsonify(trades)
+
+
+@app.route('/trades/<int:trade_id>', methods=['GET'])
+def get_trade(trade_id):
+    for trade in trades:
+        if trade.get('id') == trade_id:
+            return jsonify(trade)
+    return jsonify({'error': 'Trade not found'}), 404
+
+
+@app.route('/trades/<int:trade_id>', methods=['DELETE'])
+def delete_trade(trade_id):
+    for i, trade in enumerate(trades):
+        if trade.get('id') == trade_id:
+            # Reverse trade from positions
+            qty = trade['quantity']
+            if trade['action'] == 'buy':
+                positions[trade['symbol']] = (
+                    positions.get(trade['symbol'], 0) - qty
+                )
+            else:
+                positions[trade['symbol']] = (
+                    positions.get(trade['symbol'], 0) + qty
+                )
+            trades.pop(i)
+            storage.save_data({
+                'positions': positions,
+                'trades': trades,
+                'next_id': next_id,
+            })
+            return jsonify({'status': 'deleted'})
+    return jsonify({'error': 'Trade not found'}), 404
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/tradrxbridge/cli.py
+++ b/tradrxbridge/cli.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+import os
+
+import requests
+
+
+def _make_url(path: str) -> str:
+    """Join API_URL with path without losing any base prefix."""
+    return f"{API_URL.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _request_json(method: str, path: str, **kwargs):
+    """Send an HTTP request and return the parsed JSON response."""
+    resp = requests.request(method, _make_url(path), **kwargs)
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        raise SystemExit(f"Request failed: {exc}") from exc
+    try:
+        return resp.json()
+    except requests.JSONDecodeError as exc:
+        raise SystemExit(
+            f"Invalid JSON response from server: {resp.text!r}"
+        ) from exc
+
+
+DEFAULT_API_URL = 'http://localhost:5001'
+# The API URL can also be set via the API_URL environment variable
+API_URL = os.environ.get('API_URL', DEFAULT_API_URL)
+
+
+def place_trade(symbol, action, quantity, price):
+    data = {
+        'symbol': symbol,
+        'action': action,
+        'quantity': quantity,
+        'price': price
+    }
+    return _request_json('post', '/trade', json=data)
+
+
+def show_positions():
+    return _request_json('get', '/positions')
+
+
+def show_trades():
+    return _request_json('get', '/trades')
+
+
+def trade_info(trade_id):
+    return _request_json('get', f'/trades/{trade_id}')
+
+
+def cancel_trade(trade_id):
+    return _request_json('delete', f'/trades/{trade_id}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description=(
+            'TradrXBridge CLI. Overrides API_URL environment variable '
+            'if --api is provided.'
+        )
+    )
+    parser.add_argument('--api', default=API_URL, help='API base URL')
+    subparsers = parser.add_subparsers(dest='command')
+
+    trade_parser = subparsers.add_parser('trade')
+    trade_parser.add_argument('symbol')
+    trade_parser.add_argument('action', choices=['buy', 'sell'])
+    trade_parser.add_argument('quantity', type=float)
+    trade_parser.add_argument('price', type=float)
+
+    subparsers.add_parser('positions')
+    subparsers.add_parser('trades')
+    trade_info_parser = subparsers.add_parser('trade-info')
+    trade_info_parser.add_argument('id', type=int)
+    cancel_parser = subparsers.add_parser('cancel')
+    cancel_parser.add_argument('id', type=int)
+
+    args = parser.parse_args()
+
+    API_URL = args.api
+
+    if args.command == 'trade':
+        resp = place_trade(args.symbol, args.action, args.quantity, args.price)
+        print(json.dumps(resp, indent=2))
+    elif args.command == 'positions':
+        print(json.dumps(show_positions(), indent=2))
+    elif args.command == 'trades':
+        print(json.dumps(show_trades(), indent=2))
+    elif args.command == 'trade-info':
+        print(json.dumps(trade_info(args.id), indent=2))
+    elif args.command == 'cancel':
+        print(json.dumps(cancel_trade(args.id), indent=2))
+    else:
+        parser.print_help()

--- a/tradrxbridge/storage.py
+++ b/tradrxbridge/storage.py
@@ -1,0 +1,21 @@
+import json
+import os
+
+DATA_FILE = os.environ.get('TRADRX_DATA_FILE', 'tradrx_data.json')
+
+
+def load_data():
+    """Load trading data from disk."""
+    if not os.path.exists(DATA_FILE):
+        return {'positions': {}, 'trades': [], 'next_id': 1}
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    if 'next_id' not in data:
+        data['next_id'] = len(data.get('trades', [])) + 1
+    return data
+
+
+def save_data(data):
+    """Persist trading data to disk."""
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f)


### PR DESCRIPTION
## Summary
- improve API URL joining in CLI with helper function
- add common request helper and better error handling

## Testing
- `flake8`
- `python -m py_compile tradrxbridge/*.py`
- `FLASK_APP=tradrxbridge.app flask run -p 5001 --no-reload &`
- `python tradrxbridge/cli.py --api http://127.0.0.1:5001 trade BTC buy 1 30000`
- `python tradrxbridge/cli.py --api http://127.0.0.1:5001 positions`
- `python tradrxbridge/cli.py --api http://127.0.0.1:5001 trade-info 4`
- `python tradrxbridge/cli.py --api http://127.0.0.1:5001 cancel 4`
- `python tradrxbridge/cli.py --api http://127.0.0.1:5001/api trades # fails with 404`


------
https://chatgpt.com/codex/tasks/task_e_6874e10b24b08332aae094d3ad105784