### PR TITLE
Add AI dashboard with stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # TradrXBridge
+
+A minimal demo trading application with simple persistent storage.
+
+## Requirements
+
+- Python 3
+- Flask
+- Requests
+
+Install dependencies:
+
+```bash
+pip install Flask requests
+```
+
+By default, data is saved to `tradrx_data.json` in the current
+directory. You can set the `TRADRX_DATA_FILE` environment variable to
+change the storage path.
+
+## Running the server
+
+```bash
+flask run -p 5001 --app tradrxbridge.app
+```
+
+Trades and positions will persist between restarts using the JSON file
+described above.
+
+Open `http://localhost:5001/` in your browser to use the built-in web
+interface for submitting trades and viewing current data.
+
+An additional AI dashboard is available at `http://localhost:5001/dashboard`
+which shows basic trade statistics and a simple price prediction.
+
+Each trade receives an auto-incrementing ID and timestamp. You can
+retrieve or cancel a trade by ID using the CLI.
+
+## Using the CLI
+
+In a separate terminal, you can place trades or view positions:
+
+The CLI uses the `API_URL` environment variable to locate the server.
+You can also override it with the `--api` flag.
+
+```bash
+python tradrxbridge/cli.py --api http://localhost:5001 trade BTC buy 1 30000
+python tradrxbridge/cli.py --api http://localhost:5001 positions
+python tradrxbridge/cli.py --api http://localhost:5001 trades
+python tradrxbridge/cli.py --api http://localhost:5001 trade-info 1
+python tradrxbridge/cli.py --api http://localhost:5001 cancel 1
+```

--- a/tradrxbridge/__init__.py
+++ b/tradrxbridge/__init__.py
@@ -1,0 +1,5 @@
+"""TradrXBridge package."""
+
+from .app import app  # noqa: F401
+
+__all__ = ['app']

--- a/tradrxbridge/app.py
+++ b/tradrxbridge/app.py
@@ -1,0 +1,129 @@
+from flask import Flask, request, jsonify, render_template
+from datetime import datetime
+from . import storage
+
+app = Flask(__name__)
+
+# Persistent storage for trades and positions
+data = storage.load_data()
+positions = data.get('positions', {})
+trades = data.get('trades', [])
+next_id = data.get('next_id', len(trades) + 1)
+
+
+@app.route('/')
+def index():
+    """Render simple web interface."""
+    return render_template('index.html')
+
+
+@app.route('/dashboard')
+def dashboard():
+    """Render AI dashboard interface."""
+    return render_template('dashboard.html')
+
+
+@app.route('/dashboard-data')
+def dashboard_data():
+    """Return aggregated trade statistics."""
+    stats = {}
+    for trade in trades:
+        symbol = trade['symbol']
+        s = stats.setdefault(symbol, {'count': 0, 'total': 0.0})
+        s['count'] += 1
+        s['total'] += trade['price']
+    for s in stats.values():
+        s['average_price'] = s['total'] / s['count']
+        s['predicted_price'] = round(s['average_price'] * 1.01, 2)
+    return jsonify(stats)
+
+
+@app.route('/trade', methods=['POST'])
+def trade():
+    global next_id
+    data = request.get_json(silent=True) or {}
+    symbol = data.get('symbol')
+    action = data.get('action')  # 'buy' or 'sell'
+    try:
+        qty = float(data.get('quantity', 0))
+        price = float(data.get('price', 0))
+    except (TypeError, ValueError):
+        return jsonify({'error': 'Invalid numeric values'}), 400
+
+    if (
+        not symbol
+        or action not in {'buy', 'sell'}
+        or qty <= 0
+        or price <= 0
+    ):
+        return jsonify({'error': 'Invalid trade data'}), 400
+
+    trade = {
+        'id': next_id,
+        'symbol': symbol,
+        'action': action,
+        'quantity': qty,
+        'price': price,
+        'timestamp': datetime.utcnow().isoformat() + 'Z'
+    }
+    next_id += 1
+    trades.append(trade)
+
+    if action == 'buy':
+        positions[symbol] = positions.get(symbol, 0) + qty
+    else:
+        positions[symbol] = positions.get(symbol, 0) - qty
+
+    storage.save_data({
+        'positions': positions,
+        'trades': trades,
+        'next_id': next_id,
+    })
+
+    return jsonify({'status': 'success', 'trade': trade})
+
+
+@app.route('/positions', methods=['GET'])
+def get_positions():
+    return jsonify(positions)
+
+
+@app.route('/trades', methods=['GET'])
+def get_trades():
+    return jsonify(trades)
+
+
+@app.route('/trades/<int:trade_id>', methods=['GET'])
+def get_trade(trade_id):
+    for trade in trades:
+        if trade.get('id') == trade_id:
+            return jsonify(trade)
+    return jsonify({'error': 'Trade not found'}), 404
+
+
+@app.route('/trades/<int:trade_id>', methods=['DELETE'])
+def delete_trade(trade_id):
+    for i, trade in enumerate(trades):
+        if trade.get('id') == trade_id:
+            # Reverse trade from positions
+            qty = trade['quantity']
+            if trade['action'] == 'buy':
+                positions[trade['symbol']] = (
+                    positions.get(trade['symbol'], 0) - qty
+                )
+            else:
+                positions[trade['symbol']] = (
+                    positions.get(trade['symbol'], 0) + qty
+                )
+            trades.pop(i)
+            storage.save_data({
+                'positions': positions,
+                'trades': trades,
+                'next_id': next_id,
+            })
+            return jsonify({'status': 'deleted'})
+    return jsonify({'error': 'Trade not found'}), 404
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/tradrxbridge/cli.py
+++ b/tradrxbridge/cli.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+import os
+
+import requests
+
+
+def _make_url(path: str) -> str:
+    """Join API_URL with path without losing any base prefix."""
+    return f"{API_URL.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _request_json(method: str, path: str, **kwargs):
+    """Send an HTTP request and return the parsed JSON response."""
+    resp = requests.request(method, _make_url(path), **kwargs)
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as exc:
+        raise SystemExit(f"Request failed: {exc}") from exc
+    try:
+        return resp.json()
+    except requests.exceptions.JSONDecodeError as exc:
+        raise SystemExit(
+            f"Invalid JSON response from server: {resp.text!r}"
+        ) from exc
+
+
+DEFAULT_API_URL = 'http://localhost:5001'
+# The API URL can also be set via the API_URL environment variable
+API_URL = os.environ.get('API_URL', DEFAULT_API_URL)
+
+
+def place_trade(symbol, action, quantity, price):
+    data = {
+        'symbol': symbol,
+        'action': action,
+        'quantity': quantity,
+        'price': price
+    }
+    return _request_json('post', '/trade', json=data)
+
+
+def show_positions():
+    return _request_json('get', '/positions')
+
+
+def show_trades():
+    return _request_json('get', '/trades')
+
+
+def trade_info(trade_id):
+    return _request_json('get', f'/trades/{trade_id}')
+
+
+def cancel_trade(trade_id):
+    return _request_json('delete', f'/trades/{trade_id}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description=(
+            'TradrXBridge CLI. Overrides API_URL environment variable '
+            'if --api is provided.'
+        )
+    )
+    parser.add_argument('--api', default=API_URL, help='API base URL')
+    subparsers = parser.add_subparsers(dest='command')
+
+    trade_parser = subparsers.add_parser('trade')
+    trade_parser.add_argument('symbol')
+    trade_parser.add_argument('action', choices=['buy', 'sell'])
+    trade_parser.add_argument('quantity', type=float)
+    trade_parser.add_argument('price', type=float)
+
+    subparsers.add_parser('positions')
+    subparsers.add_parser('trades')
+    trade_info_parser = subparsers.add_parser('trade-info')
+    trade_info_parser.add_argument('id', type=int)
+    cancel_parser = subparsers.add_parser('cancel')
+    cancel_parser.add_argument('id', type=int)
+
+    args = parser.parse_args()
+
+    API_URL = args.api
+
+    if args.command == 'trade':
+        resp = place_trade(args.symbol, args.action, args.quantity, args.price)
+        print(json.dumps(resp, indent=2))
+    elif args.command == 'positions':
+        print(json.dumps(show_positions(), indent=2))
+    elif args.command == 'trades':
+        print(json.dumps(show_trades(), indent=2))
+    elif args.command == 'trade-info':
+        print(json.dumps(trade_info(args.id), indent=2))
+    elif args.command == 'cancel':
+        print(json.dumps(cancel_trade(args.id), indent=2))
+    else:
+        parser.print_help()

--- a/tradrxbridge/storage.py
+++ b/tradrxbridge/storage.py
@@ -1,0 +1,21 @@
+import json
+import os
+
+DATA_FILE = os.environ.get('TRADRX_DATA_FILE', 'tradrx_data.json')
+
+
+def load_data():
+    """Load trading data from disk."""
+    if not os.path.exists(DATA_FILE):
+        return {'positions': {}, 'trades': [], 'next_id': 1}
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    if 'next_id' not in data:
+        data['next_id'] = len(data.get('trades', [])) + 1
+    return data
+
+
+def save_data(data):
+    """Persist trading data to disk."""
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f)

--- a/tradrxbridge/templates/dashboard.html
+++ b/tradrxbridge/templates/dashboard.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>AI Dashboard</title>
+<style>
+  body { font-family: Arial, sans-serif; margin: 2em; }
+  table { border-collapse: collapse; }
+  th, td { padding: 0.5em 1em; border: 1px solid #ccc; }
+</style>
+</head>
+<body>
+<h1>AI Dashboard</h1>
+<table id="stats">
+  <thead>
+    <tr><th>Symbol</th><th>Trades</th><th>Avg Price</th><th>Predicted Price</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<script>
+async function loadStats() {
+  const resp = await fetch('/dashboard-data');
+  const data = await resp.json();
+  const tbody = document.querySelector('#stats tbody');
+  tbody.innerHTML = '';
+  for (const [symbol, info] of Object.entries(data)) {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${symbol}</td><td>${info.count}</td>` +
+      `<td>${info.average_price.toFixed(2)}</td>` +
+      `<td>${info.predicted_price.toFixed(2)}</td>`;
+    tbody.appendChild(row);
+  }
+}
+loadStats();
+</script>
+</body>
+</html>

--- a/tradrxbridge/templates/index.html
+++ b/tradrxbridge/templates/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>TradrXBridge</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 2em; }
+#trades, #positions { margin-top: 1em; }
+</style>
+</head>
+<body>
+<h1>TradrXBridge</h1>
+<form id="trade-form">
+  <label>Symbol <input type="text" id="symbol" required></label>
+  <label>Action
+    <select id="action">
+      <option value="buy">Buy</option>
+      <option value="sell">Sell</option>
+    </select>
+  </label>
+  <label>Quantity <input type="number" id="quantity" step="any" required></label>
+  <label>Price <input type="number" id="price" step="any" required></label>
+  <button type="submit">Submit</button>
+</form>
+
+<h2>Positions</h2>
+<pre id="positions"></pre>
+
+<h2>Trades</h2>
+<pre id="trades"></pre>
+
+<script>
+async function fetchJson(url, options) {
+  const resp = await fetch(url, options);
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || resp.statusText);
+  }
+  return resp.json();
+}
+
+async function load() {
+  document.getElementById('positions').textContent = JSON.stringify(
+    await fetchJson('/positions'), null, 2
+  );
+  document.getElementById('trades').textContent = JSON.stringify(
+    await fetchJson('/trades'), null, 2
+  );
+}
+
+document.getElementById('trade-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  try {
+    const data = {
+      symbol: document.getElementById('symbol').value,
+      action: document.getElementById('action').value,
+      quantity: parseFloat(document.getElementById('quantity').value),
+      price: parseFloat(document.getElementById('price').value)
+    };
+    await fetchJson('/trade', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    await load();
+  } catch (err) {
+    alert('Error: ' + err.message);
+  }
+});
+
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend CLI error handling for bad JSON responses
- serve a new AI dashboard at `/dashboard`
- provide aggregated trade stats and simple price prediction
- document the dashboard in README

## Testing
- `flake8`
- `python -m py_compile tradrxbridge/*.py`
- `FLASK_APP=tradrxbridge.app flask run -p 5001 --no-reload &`
- `curl -s http://localhost:5001/dashboard | head -n 5`
- `curl -s -X POST http://localhost:5001/trade -H 'Content-Type: application/json' -d '{"symbol":"ETH","action":"buy","quantity":2,"price":2000}'`
- `curl -s http://localhost:5001/dashboard-data`
- `python tradrxbridge/cli.py --api http://localhost:5001 positions`


------
https://chatgpt.com/codex/tasks/task_e_6874e10b24b08332aae094d3ad105784