### PR TITLE
Add TradingView charts to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TradrXBridge
 
-This repository contains a simple placeholder for the TradrXBridge website.
+This repository contains a simple placeholder interface for the TradrXBridge website.
 
-Open `index.html` in a web browser to view the site mockup.
+To preview the site, open `index.html` in a web browser. It uses `style.css` for styling and `script.js` for basic interactivity. No build step or additional dependencies are required.
+
+The page now embeds live TradingView charts. Enter any symbol (for example `BINANCE:BTCUSDT` or `NASDAQ:AAPL`) and click **Add Chart** to display a real-time graph.

--- a/index.html
+++ b/index.html
@@ -4,43 +4,38 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TradrXBridge</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #f5f7fa;
-        }
-        .container {
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 20px;
-        }
-        header, footer {
-            text-align: center;
-            padding: 1em 0;
-            background-color: #2d3436;
-            color: #ecf0f1;
-        }
-        main {
-            background-color: #ffffff;
-            padding: 20px;
-            border-radius: 4px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-    </style>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <div class="container">
         <header>
             <h1>Welcome to TradrXBridge</h1>
+            <nav>
+                <ul>
+                    <li><a href="#">Home</a></li>
+                    <li><a href="#">About</a></li>
+                    <li><a href="#">Contact</a></li>
+                </ul>
+            </nav>
         </header>
         <main>
             <p>This is a simple placeholder screen for the trading bridge website.</p>
+            <button id="infoButton">Click me</button>
+            <p id="info"></p>
+            <section id="charts">
+                <h2>Market Charts</h2>
+                <div id="symbolControls">
+                    <input id="symbolInput" type="text" placeholder="e.g., BINANCE:BTCUSDT">
+                    <button id="addChart">Add Chart</button>
+                </div>
+                <div id="chartsContainer"></div>
+            </section>
         </main>
         <footer>
             <p>&copy; 2023 TradrXBridge</p>
         </footer>
     </div>
+    <script type="text/javascript" src="https://s3.tradingview.com/tv.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const infoButton = document.getElementById('infoButton');
+    const info = document.getElementById('info');
+
+    if (infoButton) {
+        infoButton.addEventListener('click', () => {
+            info.textContent = 'TradrXBridge is under construction. Stay tuned for updates!';
+        });
+    }
+
+    const chartsContainer = document.getElementById('chartsContainer');
+    const symbolInput = document.getElementById('symbolInput');
+    const addChartBtn = document.getElementById('addChart');
+
+    function addChart(symbol) {
+        if (!window.TradingView || !chartsContainer || !symbol) return;
+        const containerId = `chart-${symbol.replace(/[^a-zA-Z0-9]/g, '-')}`;
+        const div = document.createElement('div');
+        div.id = containerId;
+        div.className = 'chart';
+        chartsContainer.appendChild(div);
+
+        new TradingView.widget({
+            container_id: containerId,
+            width: "100%",
+            height: 400,
+            symbol: symbol,
+            interval: "D",
+            timezone: "Etc/UTC",
+            theme: "light",
+            style: "1",
+            locale: "en",
+            toolbar_bg: "#f1f3f6",
+            enable_publishing: false,
+            allow_symbol_change: false
+        });
+    }
+
+    const defaultSymbols = ['BINANCE:BTCUSDT', 'BINANCE:ETHUSDT'];
+    defaultSymbols.forEach(addChart);
+
+    if (addChartBtn) {
+        addChartBtn.addEventListener('click', () => {
+            const symbol = symbolInput.value.trim();
+            if (symbol) {
+                addChart(symbol.toUpperCase());
+                symbolInput.value = '';
+            }
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,71 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f5f7fa;
+}
+
+.container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header, footer {
+    text-align: center;
+    padding: 1em 0;
+    background-color: #2d3436;
+    color: #ecf0f1;
+}
+
+main {
+    background-color: #ffffff;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    text-align: center;
+}
+
+nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+}
+
+nav li {
+    margin: 0 10px;
+}
+
+nav a {
+    color: #ecf0f1;
+    text-decoration: none;
+}
+
+button {
+    margin-top: 20px;
+    padding: 10px 20px;
+    font-size: 1rem;
+}
+#symbolControls {
+    margin-top: 20px;
+}
+
+#symbolControls input {
+    padding: 5px;
+    width: 200px;
+}
+
+#chartsContainer {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.chart {
+    width: 100%;
+    max-width: 700px;
+    margin: 20px 0;
+}


### PR DESCRIPTION
## Summary
- Embed TradingView widget and controls to display live market charts for multiple symbols.
- Add basic styling for chart controls and containers.
- Document how to load charts in README.

## Testing
- `python -m http.server 8001`


------
https://chatgpt.com/codex/tasks/task_e_6874fab719b4833284763752ce110cb1